### PR TITLE
only allow RFC3339 timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,8 @@ To properly represent trajectories, the `geometry` field of a item **must** have
 
 Once that is the case, the `datetimes` property has to be an array with the same number of elements
 as the `coordinates` property of the geometry. Its values **must** describe time instants in
-monotonic increasing order (without duplicated values) and may be:
-- numeric values of milliseconds since 1970-01-01 00:00:00 UTC (unix timestamps)
-- strings describing IETF RFC 3339 encoded timestamps
-- strings describing ISO8601 encoded timestamps following the Gregorian calendar
+monotonic increasing order (without duplicated values) and **must** be formatted as IETF RFC 3339 encoded timestamps.
 
-Mixing different kinds of timestamp encodings is not allowed.
 
 The `datetime` property from the base metadata should be `null`, and the `start_datetime` and
 `end_datetime` properties should have the same value as the first and last values from `datetimes`.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Once that is the case, the `datetimes` property has to be an array with the same
 as the `coordinates` property of the geometry. Its values **must** describe time instants in
 monotonic increasing order (without duplicated values) and **must** be formatted as IETF RFC 3339 encoded timestamps.
 
+The OGC moving features standard also allows UNIX timestamps (milliseconds since 1970-01-01 00:00:00 UTC) and ISO8601-encoded timestamps in the Gregorian calendar. These have been explicitly disallowed to follow common practice in the STAC ecosystem.
 
 The `datetime` property from the base metadata should be `null`, and the `start_datetime` and
 `end_datetime` properties should have the same value as the first and last values from `datetimes`.


### PR DESCRIPTION
- [x] closes #11

As pointed out in #11, there's no benefit in allowing more timestamp formats. Funnily enough, this is what the schema did all along, so only the readme had to be changed.